### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,7 +19,6 @@ client_scripts {
     '@PolyZone/CircleZone.lua',
     '@PolyZone/ComboZone.lua',
     'client/main.lua',
-    'client/police.lua'
 }
 
 server_scripts {


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.